### PR TITLE
[Finishes #163674704] Add Get all offices endpoint

### DIFF
--- a/app/v1/__init__.py
+++ b/app/v1/__init__.py
@@ -18,6 +18,7 @@ v1_app.add_url_rule('/parties/<int:partyId>',view_func=Parties.delete_party, met
 #office  module Urls 
 v1_app.add_url_rule('/offices',view_func=Offices.create_party, methods=['POST'])
 v1_app.add_url_rule('/offices/<int:office_id>',view_func=Offices.get_details, methods=['GET'])
+v1_app.add_url_rule('/offices',view_func=Offices.get_all_offices, methods=['GET'])
 
 
  

--- a/app/v1/views/offices.py
+++ b/app/v1/views/offices.py
@@ -63,3 +63,11 @@ class Offices(Views):
         return make_response(jsonify(
             {'status':404, "error":'Office with id {} not found'.format(office_id)}
         ))
+
+    @classmethod
+    def get_all_offices(cls):
+        """Lists all parties"""
+        res = jsonify({"status": 200,
+                        'data': [officeList[i].get_details() for i in officeList]
+                        })
+        return make_response(res, 200)

--- a/tests/test_v1_offices.py
+++ b/tests/test_v1_offices.py
@@ -35,6 +35,18 @@ class TestOffices(BaseTest):
         self.assertEqual(result_get.status_code, 200)
 
         data_check_get = json.loads(result_get.data)
-        self.check_standard_reply(dataCheck, 200 )
+        self.check_standard_reply(data_check_get, 200 )
         self.assertEqual(data_check_get['data']['name'],office2['name'])
         
+
+    def test_get_all_offices(self):
+        office3 = {
+            'name': 'Office c',
+            'type': 'legislative'
+            }
+        self.client().post("/api/v1/offices", data=office3)
+        result_get = self.client().get("/api/v1/offices")
+        self.assertEqual(result_get.status_code, 200)
+
+        data_check_get = json.loads(result_get.data)
+        self.check_standard_reply(data_check_get, 200 )


### PR DESCRIPTION
**What does this PR do?**
creates an API endpoint to get a list of political parties
**Description of the task**
A list of political offices is retrieved by sending a **GET** request to the endpoint /api/v1/parties/
**on success** 
```
{
    "data": [{
        "id": 1,
        "name": "Office name a",
        "type": "Type of office"
    },
{
        "id": 1,
        "name": "Office name b",
        "type": "Type of office"
    }
],
    "status": 200
}
```
**if party no parties are there** 
```
{
    "data":[],
    "status": 404
}

```
**How to manually test the task**
```
git clone https://github.com/martinMutuma/politicoApi-c2.git
git checkout ft-get-all-offices-163674704

```

use postman to test the endpoint 


**Relevant Pivotal Tracker stories**
[#163674704](https://www.pivotaltracker.com/story/show/163674704)
