### PR TITLE
#164081078 Add env and more tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,9 +2,11 @@
 omit = 
         travis/*
         travis/
+        v1/
         
 [report]    
 omit = 
       travis/*
       travis/
+      v1/
     

--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+ADMIN_EMAIL=admin@mail.com
+ADMIN_FIRST_NAME=admin
+ADMIN_LAST_NAME =default
+ADMIN_PASSWORD=password
+ADMIN_PASSPORT="www.url.com/admin.jpg"

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+ADMIN_EMAIL=admin@mail.com
+ADMIN_FIRST_NAME=admin
+ADMIN_LAST_NAME =default
+ADMIN_PASSWORD=password
+ADMIN_PASSPORT="www.url.com/admin.jpg"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ services:
 
  
 script:
-   - python -m pytest  --cov=app
+   - python -m pytest  --cov=app/v2
   
 
 after_success:
-  - codeclimate -test-reporter
+  - coveralls
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ## Political 
 [![Build Status](https://travis-ci.org/martinMutuma/politicoApi-c2.svg?branch=develop)](https://travis-ci.org/martinMutuma/politicoApi-c2)
 [![Maintainability](https://api.codeclimate.com/v1/badges/b9d93f75e153d157012e/maintainability)](https://codeclimate.com/github/martinMutuma/politicoApi-c2/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/b9d93f75e153d157012e/test_coverage)](https://codeclimate.com/github/martinMutuma/politicoApi-c2/test_coverage)
 [![Coverage Status](https://coveralls.io/repos/github/martinMutuma/politicoApi-c2/badge.svg?branch=develop)](https://coveralls.io/github/martinMutuma/politicoApi-c2?branch=develop)
 
 ## Description
@@ -11,14 +10,13 @@ while building trust in the process through transparency.
 Political is impremented  using python data structures
 
 ## Setup and installation
-1. Clone the repo
+ 1. Clone the repo
    ```git
         git clone https://github.com/martinMutuma/politicoApi-c2.git
-
         cd politicoApi-c2
    ```
 
-2. Set up virtualenv
+ 2. Set up virtualenv
 
         
    ```bash
@@ -31,7 +29,7 @@ Political is impremented  using python data structures
         python -m virtualenv venv
    `````
 
-3. Activate virtualenv
+ 3. Activate virtualenv
 
         
    ```bash
@@ -43,14 +41,14 @@ Political is impremented  using python data structures
         #windows
         venv/Scripts/activate
    ```
-4. Install dependencies
+ 4. Install dependencies
 
    ```bash
         #Universal windows and linux
         pip install -r requirements.txt
    ```
 
-5. Setup env variables
+ 5. Setup env variables
    ```bash  
         #linux
         - export FLASK_APP=run.py
@@ -65,11 +63,11 @@ Political is impremented  using python data structures
         - set FLASK_ENV=development
         - set CONNECTION_STRING=dbname='political_test' user='postgres' host='localhost' password='your postgress pass' port='5432'
    ```
-6. Manually Running tests
+ 6. Manually Running tests
       ```
          python -m pytest --cov=app
       ```
-7. Start the server
+ 7. Start the server
       ```
          flask run
       ```
@@ -77,16 +75,7 @@ Political is impremented  using python data structures
 App is available at 
 
 1. [Localhost](http://127.0.0.1:5000/)
-
 2. [Heroku](https://mmmpolitical.herokuapp.com)
-
-Default admin 
-
-```
-     email: admin@mail.com
-     password:password
-```
-
 
 ##Political Endpoints
 
@@ -94,9 +83,9 @@ Default admin
 | -------- | ------------------------------------ | -------------------------------------       |
 | `POST`   | `/api/v1/parties`                    | Create a new party                          |
 | `GET`    | `/api/v1/parties`                    | View all parties                            |
-| `GET`    | `/api/v1/parties/<int:party_id>`      | Get party details by party Id               |
-| `PATCH`  | `/api/v1/parties/<int:party_id>/name` | Update a party  name                        |
-| `DELETE` | `/api/v1/parties/<int:party_id>`      | Delete a party by Id                        |
+| `GET`    | `/api/v1/parties/<int:party_id>`     | Get party details by party Id               |
+| `PATCH`  | `/api/v1/parties/<int:party_id>/name`| Update a party  name                        |
+| `DELETE` | `/api/v1/parties/<int:party_id>`     | Delete a party by Id                        |
 | `GET`    | `/api/v1/offices`                    | View All offices                            |
 | `POST`   | `/api/v1/offices`                    | Post a new office                           |
 | `GET`    | `/api/v1/offices/<int:office_id>`    | Get a specific office                       |
@@ -115,14 +104,16 @@ Default admin
 | `GET`    | `/api/v2/offices/<int:office_id>`         | Get a specific office                       |
 | `POST`   | `/api/v2/auth/signup`                     | Create User                                 |
 | `POST`   | `/api/v2/auth/login`                      | Login to system                             |
+| `GET`    | `/api/v2/auth/admin/<int:user_id>`        | Make user an Admin                          |
 | `POST`   | `/api/v2/offices/<int:office_id>/register`| Register candidate                          |
+| `GET`    | `/api/v2/candidates`                      | Get all candidates                          |
 | `POST`   | `/api/v2/offices/vote`                    | Cast vote                                   |
-| `GET`    | `/api/v2/offices/<int:office_id>/result`  | Get specific office results               |
+| `GET`    | `/api/v2/offices/<int:office_id>/result`  | Get specific office results                 |
 
 ## Project managemnt 
 [Pivotal Tracker](https://www.pivotaltracker.com/n/projects/2241695)
 
 ## Project documentation and endpoint Manual test
 
-### [Api v2 Documentation on Apiary](https://political.docs.apiary.io/)
-### [Api V2 Documentation on Postman](https://documenter.getpostman.com/view/3383651/S11BzhxS)
+ ### [Api v2 Documentation on Apiary](https://political.docs.apiary.io/)
+ ### [Api V2 Documentation on Postman](https://documenter.getpostman.com/view/3383651/S11BzhxS)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,9 +2,9 @@
 app/__init__.py
 """
 
-
+import os
 from flask import Flask
-from instance.config import configs, default_admin
+from instance.config import configs
 from app.v1 import v1_app
 from app.v2 import v2_app
 from app.db_setup import DbSetup
@@ -34,9 +34,7 @@ def create_app(config='development'):
     app.register_blueprint(v2_app, url_prefix='/api/v2')
 
     db = DbSetup(config)
-    # db.drop()
     db.create_tables()
-    # db.drop()
     create_default_admin()
     return app
 
@@ -47,8 +45,18 @@ def create_default_admin():
 
     user = None
     user = UserModel()
-    user.where(dict(email=default_admin['email']))
-    if user.check_exist() is not True:
-        save_data = user.clean_insert_dict(default_admin,  full=False)
-        save_data['password'] = hash_password(default_admin['password'])
-        user.insert(save_data)
+    email = os.getenv('ADMIN_EMAIL')
+    firstname = os.getenv('ADMIN_FIRST_NAME')
+    lastname = os.getenv('ADMIN_LAST_NAME')
+    password = os.getenv('ADMIN_PASSWORD')
+    passporturlstring = os.getenv('ADMIN_PASSPORT')
+    default_admin = dict(firstname=firstname, lastname=lastname,
+                         email=email, password=password, isAdmin=True,
+                         passporturlstring=passporturlstring)
+    if email is not None:
+        user.where(dict(email=default_admin['email']))
+        if user.check_exist() is not True:
+            save_data = user.clean_insert_dict(default_admin,  full=False)
+            save_data['password'] = hash_password(default_admin['password'])
+            user.insert(save_data)
+    

--- a/app/db_setup.py
+++ b/app/db_setup.py
@@ -49,7 +49,6 @@ class DbSetup:
         queries = cursor.fetchall()
         for i in queries:
             cursor.execute(i[0])
-            self.commit()
 
         self.commit()
 

--- a/app/v2/__init__.py
+++ b/app/v2/__init__.py
@@ -1,5 +1,4 @@
 
-from app.v2.views import Views
 from app.v2.views import results
 from app.v2.views import votes
 from app.v2.views import candidates
@@ -44,9 +43,11 @@ v2_app.add_url_rule('/offices/<int:office_id>/result',
 v2_app.add_url_rule('/auth/login', view_func=auth.login, methods=['POST'])
 v2_app.add_url_rule('/auth/signup', view_func=auth.signup, methods=['POST'])
 v2_app.add_url_rule('/auth', view_func=auth.test, methods=['POST'])
+v2_app.add_url_rule('/auth/admin/<int:user_id>',
+                    view_func=auth.make_admin, methods=['GET'])
 
 # votes votes
 v2_app.add_url_rule('/votes', view_func=votes.vote, methods=['POST'])
-
-# Clear data
-v2_app.add_url_rule('/d', view_func=Views.destroy_db)
+# candidates
+v2_app.add_url_rule(
+    '/candidates', view_func=candidates.get_all_candidates, methods=['GET'])

--- a/app/v2/models/__init__.py
+++ b/app/v2/models/__init__.py
@@ -60,7 +60,6 @@ class BaseModel(object):
         set_values = ",".join(formated)
         query = "INSERT INTO {} ({}) VALUES({}) RETURNING {};".format(
             self.table_name, columns, set_values, ','.join(self.sub_set_cols))
-
         self.execute_query(query, True)
         try:
             result = self.cursor.fetchone()
@@ -69,7 +68,7 @@ class BaseModel(object):
                 self.add_result_to_self(result)
         except psycopg2.ProgrammingError as errorx:
             result = None
-            print(errorx)
+            self.errors.append(errorx)
 
     def update(self, data_update_dict, pry_key):
         """Compiles the Update querr
@@ -191,9 +190,11 @@ class BaseModel(object):
                 self.connection.commit()
             self.where_clause = ''
         except psycopg2.Error as errorx:
+            print("exe===============exec===================", errorx)
             if config != 'production':
-                print(errorx)
+                pass
             self.errors.append("Error executing `{}`".format(query))
+            self.connection.rollback()
             return False
 
     def clean_insert_dict(self, dynamic_dict={}, full=True):

--- a/app/v2/views/__init__.py
+++ b/app/v2/views/__init__.py
@@ -51,12 +51,3 @@ class Views(object):
                 {'status': 400, 'error': msg, 'data': []})
             return abort(make_response(res, 400))
         return True
-
-    @staticmethod
-    def destroy_db():
-        """
-        used by when testing incase one wants to
-        clean up the data and test a flesh
-
-        """
-        return make_response("Done", 200)

--- a/app/v2/views/auth.py
+++ b/app/v2/views/auth.py
@@ -189,3 +189,18 @@ def hash_password(password):
 
     hash_object = hashlib.md5(password.encode())
     return hash_object.hexdigest()
+
+
+@require_auth_admin
+def make_admin(user_id):
+    data = dict(isadmin=True)
+    user = UserModel()
+    user.where(dict(id=user_id))
+    if user.check_exist() is True and user.id is not None:
+        update_data = user.clean_insert_dict(data, False)
+        user.update(update_data, user_id)
+        res = {"status": 202, "data": user.sub_set()}
+    else:
+        msg = "User not found"
+        res = {"status": 404, 'error': msg}
+    return make_response(jsonify(res), res['status'])

--- a/app/v2/views/candidates.py
+++ b/app/v2/views/candidates.py
@@ -42,3 +42,20 @@ def register(office_id):
         return make_response(jsonify(dict(data=data, status=status)), status)
     res = {"error": "Could not create Candidate", 'status': 400}
     return make_response(jsonify(res), 400)
+
+
+@auth.require_auth
+def get_all_candidates():
+    """Get a list of all candidates
+    Returns:
+        [api response] -- [with all candidates]
+    """
+
+    candidate_model = CandidateModel()
+    select_cols = candidate_model.sub_set_cols
+    candidate_model.select(select_cols)
+    all_candidates = candidate_model.get(False)
+    res = jsonify({"status": 200,
+                   'data': all_candidates
+                   })
+    return make_response(res, 200)

--- a/app/v2/views/offices.py
+++ b/app/v2/views/offices.py
@@ -97,7 +97,7 @@ class Offices(Views):
         return make_response(jsonify(
             {'status': 404,
                 "error": 'Office with id {} not found'.format(office_id)}
-        ))
+        ), 404)
 
     @classmethod
     @auth.require_auth

--- a/app/v2/views/parties.py
+++ b/app/v2/views/parties.py
@@ -82,12 +82,10 @@ class Parties(Views):
         if party_exists is not None:
             update_data = party.clean_insert_dict(patch_data, False)
             party.update(update_data, partyId)
-            print(party.__dict__)
             res = {"status": 202, "data": party.sub_set()}
         else:
             msg = "Party with id {} not found".format(partyId)
-            res = jsonify(
-                {"status": 404, 'error': msg})
+            res = {"status": 404, 'error': msg}
         return make_response(jsonify(res), res['status'])
 
     @classmethod

--- a/app/v2/views/validate.py
+++ b/app/v2/views/validate.py
@@ -3,7 +3,6 @@ app/v1/views/validate.py
 """
 
 import re
-from urllib.parse import urlparse
 special_chars = r'[0-9~!@#$%^&*()_-`{};:\'"\|/?.>,<]'
 
 
@@ -66,15 +65,10 @@ class Validate:
         Takes url as the parameter
 
         """
-        try:
-            result = urlparse(Url)
-            if all([result.scheme, result.netloc, result.path]):
-                return cls.make_retun_dict(True)
-            else:
-                return cls.make_retun_dict(False, "Must be a valid Url")
-        except Exception as e:
-            cls.errors.append(e)
+        pattern = r"^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/|www\.)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$"
+        if not re.match(pattern, Url):
             return cls.make_retun_dict(False, "Must be a valid Url")
+        return cls.make_retun_dict(True, "valid url")
 
     @classmethod
     def validate_email(cls, mail):

--- a/app/v2/views/votes.py
+++ b/app/v2/views/votes.py
@@ -1,7 +1,6 @@
-from flask import make_response, jsonify
+from flask import make_response, jsonify, request
 from app.v2.models.candidate_model import CandidateModel
 from app.v2.models.user_model import UserModel
-from app.v2.models.office_model import OfficeModel
 from app.v2.models.vote_model import VoteModel
 from app.v2.views import Views
 from app.v2.views import auth
@@ -11,21 +10,20 @@ from app.v2.views import auth
 def vote():
     """Cast vote"""
     data = Views.get_data()
-    required_fields = ['createdBy', 'candidate_id', 'office_id']
+    required_fields = ['candidate_id', 'office_id']
     Views.check_for_required_fields(
         fields=required_fields, dataDict=data)
 
     user = UserModel()
+    data['createdBy'] = request.user.get('id')
     error_message = []
     if user.get_one(data['createdBy']) is None:
         error_message.append('User Does not exist')
 
-    office = OfficeModel()
-    if office.get_one(data['office_id']) is None:
-        error_message.append('Office Does not exist')
     candidate = CandidateModel()
+    candidate.where({'office_id': data['office_id']})
     if candidate.get_one(data['candidate_id']) is None:
-        error_message.append('Candidate does not exist')
+        error_message.append('Candidate does not exist for that office')
     vote = VoteModel()
     where_data = {'office_id': data['office_id'],
                   'createdBy': data['createdBy']}

--- a/instance/config.py
+++ b/instance/config.py
@@ -31,6 +31,3 @@ configs = dict(
     production=Config,
     development=DevelopmentConfig
 )
-default_admin = dict(firstname='Admin', lastname="Default",
-                     email='admin@mail.com', password='password', isAdmin=True,
-                     passporturlstring='www.urladmon.com')

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,8 @@ coverage==4.5.2
 coveralls==1.5.1
 cryptography==2.5
 docopt==0.6.2
+entrypoints==0.3
+flake8==3.7.6
 Flask==1.0.2
 gunicorn==19.9.0
 idna==2.8
@@ -31,12 +33,15 @@ psycopg2==2.7.7
 py==1.7.0
 pycodestyle==2.5.0
 pycparser==2.19
+pyflakes==2.1.0
 PyJWT==1.7.1
 pylint==2.2.2
 # pypiwin32==223
 pytest==4.2.0
 pytest-cov==2.6.1
+python-dotenv==0.10.1
 # pywin32==224
+PyYAML==3.13
 requests==2.21.0
 six==1.12.0
 urllib3==1.24.1

--- a/run.py
+++ b/run.py
@@ -2,6 +2,8 @@
 
 from app import create_app
 from flask import make_response, jsonify
+from dotenv import load_dotenv
+load_dotenv()
 
 polApp = create_app('development')
 @polApp.route('/', methods=['GET'])

--- a/tests/v2/__init__.py
+++ b/tests/v2/__init__.py
@@ -72,12 +72,3 @@ class BaseTest(unittest.TestCase):
             'hqAddress': '23 jumpstreet',
             'logoUrl': 'www.url.com/ ' + BaseTest().random_name(10),
         }
-
-    def tearDown(self):
-        pass
-        # db.drop()
-
-    @classmethod
-    def tearDownClass(cls):
-        pass
-        # db.drop()

--- a/tests/v2/test_auth.py
+++ b/tests/v2/test_auth.py
@@ -12,6 +12,14 @@ class TestAuth(BaseTest):
         datacheck = json.loads(result.data)
         self.check_standard_reply(datacheck, 201)
 
+    def test_auth_signup_with_missing_data(self):
+        data = self.generate_user()
+        del data['email']
+        result = self.send_auth_request('/api/v2/auth/signup', 'POST', data)
+        self.assertEqual(result.status_code, 400)
+        datacheck = json.loads(result.data)
+        self.check_standard_reply(datacheck, 400, True)
+
     def test_auth_login(self):
         data = self.generate_user()
         result = self.send_auth_request('/api/v2/auth/signup', 'POST', data)
@@ -31,6 +39,14 @@ class TestAuth(BaseTest):
             '/api/v2/auth/login', 'POST', login_data)
         datacheck2 = json.loads(result2.data)
         self.check_standard_reply(datacheck2, 400, True)
+
+    def test_make_user_admin(self):
+        """Test Make user admin"""
+
+        resultGet = self.send_auth_request("/api/v2/auth/admin/5656", 'GET')
+        self.assertEqual(resultGet.status_code, 404)
+        dataCheckGet = json.loads(resultGet.data)
+        self.check_standard_reply(dataCheckGet, 200, True)
 
     def generate_user(self):
         return {

--- a/tests/v2/test_candidates.py
+++ b/tests/v2/test_candidates.py
@@ -23,3 +23,19 @@ class TestCandidate(BaseTest):
             "/api/v2/offices/{}/register".format(office_id), "POST",
             data=candidate)
         self.assertEqual(resultC.status_code, 201)
+
+    def test_create_candidate_with_wrong_data(self):
+        user_id = 696994040004004
+        candidate = dict(user_id=str(user_id))
+        resultC = self.send_auth_request(
+            "/api/v2/offices/78996643345/register", "POST",
+            data=candidate)
+        self.assertEqual(resultC.status_code, 400)
+
+    def test_get_all_parties(self):
+        """Test get candidates"""
+        resultGet = self.send_auth_request("/api/v2/candidates", 'GET')
+        self.assertEqual(resultGet.status_code, 200)
+
+        dataCheckGet = json.loads(resultGet.data)
+        self.check_standard_reply(dataCheckGet, 200)

--- a/tests/v2/test_models.py
+++ b/tests/v2/test_models.py
@@ -1,0 +1,46 @@
+from tests.v2 import BaseTest
+from app.v2.models.user_model import UserModel
+from app.v2.models.party_model import PartyModel
+from app.v2.models.candidate_model import CandidateModel
+from app.v2.models.office_model import OfficeModel
+from app.v2.models.vote_model import VoteModel
+
+
+class TestModels(BaseTest):
+
+    def test_user_model(self):
+        user_data = self.generate_user()
+        user = UserModel()
+        user.create_user(user_data)
+        self.assertEqual(user.email, user_data['email'])
+        user.insert(user_data)
+        self.assertEqual(type(user.id), int)
+
+    def test_office_model(self):
+        office_data = self.generate_random_office()
+        office = OfficeModel()
+        office.create_office(office_data['name'], office_data['type'])
+        self.assertEqual(office.name, office_data['name'])
+        office.insert(office_data)
+        self.assertEqual(type(office.id), int)
+
+    def test_party_model(self):
+        party_data = self.gen_party()
+        party = PartyModel()
+        party.create(party_data['name'],
+                     party_data['hqAddress'], party_data['logoUrl'])
+        self.assertEqual(party.name, party_data['name'])
+        party.insert(party_data)
+        self.assertEqual(type(party.id), int)
+
+    def test_candidate_model(self):
+        candidate = CandidateModel()
+        candidate.create(1, 1, 1)
+        self.assertEqual(candidate.office_id, 1)
+        self.assertIsInstance(candidate, CandidateModel)
+
+    def test_vote_model(self):
+        vote = VoteModel()
+        vote.create(1, 3, 4)
+        self.assertEqual(vote.office_id, 1)
+        self.assertIsInstance(vote, VoteModel)

--- a/tests/v2/test_offices.py
+++ b/tests/v2/test_offices.py
@@ -25,6 +25,29 @@ class TestOffices(BaseTest):
         dataCheck = json.loads(result.data)
         self.check_standard_reply(dataCheck, 201)
 
+    def test_create_office_missing_field(self):
+        office = self.generate_random_office()
+        del office['name']
+        result = self.send_auth_request("/api/v2/offices", "POST", data=office)
+        self.assertEqual(result.status_code, 400)
+        dataCheck = json.loads(result.data)
+        self.check_standard_reply(dataCheck, 400, True)
+
+    def test_create_office_no_data(self):
+        result = self.send_auth_request("/api/v2/offices", "POST")
+        self.assertEqual(result.status_code, 400)
+        dataCheck = json.loads(result.data)
+        self.check_standard_reply(dataCheck, 400, True)
+
+    def test_create_office_duplicate(self):
+        self.send_auth_request(
+            "/api/v2/offices", "POST", data=self.office1)
+        result = self.send_auth_request(
+            "/api/v2/offices", "POST", data=self.office1)
+        self.assertEqual(result.status_code, 400)
+        dataCheck = json.loads(result.data)
+        self.check_standard_reply(dataCheck, 400, True)
+
     def test_get_specific_office_details(self):
         office2 = self.generate_random_office()
         result = self.send_auth_request(
@@ -38,6 +61,15 @@ class TestOffices(BaseTest):
         data_check_get = json.loads(result_get.data)
         self.check_standard_reply(data_check_get, 200)
         self.assertEqual(data_check_get['data']['name'], office2['name'])
+
+    def test_get_specif_office_details_office_not_exist(self):
+        resultGet1 = self.send_auth_request(
+            "/api/v2/offices/2999999", 'GET')
+        self.assertEqual(resultGet1.status_code, 404)
+
+        dataCheckGet = json.loads(resultGet1.data)
+
+        self.check_standard_reply(dataCheckGet, 404, True)
 
     def test_get_all_offices(self):
         office3 = {

--- a/tests/v2/test_parties.py
+++ b/tests/v2/test_parties.py
@@ -80,6 +80,14 @@ class TestParties(BaseTest):
         self.assertEqual(dataCheckGet['data']
                          ['name'], dataCheck['data']['name'])
 
+    def test_get_party_details_party_not_exist(self):
+        resultGet1 = self.send_auth_request(
+            "/api/v2/parties/7676676898", 'GET')
+        self.assertEqual(resultGet1.status_code, 404)
+
+        dataCheckGet = json.loads(resultGet1.data)
+        self.check_standard_reply(dataCheckGet, 404, True)
+
     def test_get_all_parties(self):
         """Test get parties"""
         resultGet = self.send_auth_request("/api/v2/parties/", 'GET')

--- a/tests/v2/test_results.py
+++ b/tests/v2/test_results.py
@@ -1,0 +1,17 @@
+from tests.v2 import BaseTest
+from app.v2.models.vote_model import VoteModel
+
+
+class TestResults(BaseTest):
+    """Tests for autn"""
+
+    def test_results(self):
+        votes = VoteModel()
+        results = votes.get(True)
+        print(results)
+        office_id = 0
+        if results is not None:
+            office_id = results['office_id']
+        url = '/api/v2/offices/{}/result'.format(office_id)
+        get_result = self.send_auth_request(url, 'GET')
+        self.assertEqual(get_result.status_code, 200, "Result was not found")

--- a/tests/v2/test_validate.py
+++ b/tests/v2/test_validate.py
@@ -1,0 +1,63 @@
+from tests.v2 import BaseTest
+from app.v2.views.validate import Validate
+
+
+class TestValidate(BaseTest):
+    """Tests for validatation class """
+
+    def test_required(self):
+        required = ['name', 'age']
+        data_submitted = {'name': 'my name', 'age': 45}
+        validate = Validate.required(required, data_submitted)
+        self.assertEqual(validate['status'], True)
+
+    def test_required_missing(self):
+        required = ['name', 'age']
+        data_submitted = {'name': 'my name', }
+        validate = Validate.required(required, data_submitted)
+        self.assertEqual(validate['status'], False)
+
+    def test_validate_name(self):
+        name = 'Good name'
+        validate = Validate.validate_name(name)
+        self.assertEqual(validate['status'], True)
+
+    def test_validate_name_less_four_chars(self):
+        name = 'ame'
+        validate = Validate.validate_name(name)
+        self.assertEqual(validate['status'], False)
+
+    def test_validate_name_special_chars(self):
+        name = 'a4#$$$$#%%me'
+        validate = Validate.validate_name(name)
+        self.assertEqual(validate['status'], False)
+
+    def test_validate_url(self):
+        url = "www.google.com"
+        validate = Validate.validate_url(url)
+        self.assertEqual(validate['status'], True)
+
+    def test_validate_url_wrong(self):
+        url = "www.google"
+        validate = Validate.validate_url(url)
+        self.assertEqual(validate['status'], False)
+
+    def test_validate_length(self):
+        name = 'my name'
+        validate = Validate.validate_length(name)
+        self.assertEqual(validate['status'], True)
+
+    def test_validate_length_short(self):
+        name = 'my name'
+        validate = Validate.validate_length(name, 10)
+        self.assertEqual(validate['status'], False)
+
+    def test_validate_email(self):
+        email = 'mail@mial.com'
+        validate = Validate.validate_email(email)
+        self.assertEqual(validate['status'], True)
+
+    def test_validate_email_wron(self):
+        email = 'mailmial.com'
+        validate = Validate.validate_email(email)
+        self.assertEqual(validate['status'], False)

--- a/tests/v2/test_votes.py
+++ b/tests/v2/test_votes.py
@@ -32,3 +32,10 @@ class TestVotes(BaseTest):
             "/api/v2/votes", "POST", data=vote)
         print(json.loads(result_vote.data))
         self.assertEqual(result_vote.status_code, 201)
+
+    def test_cast_vote_wrong_data(self):
+        vote = {'createdBy': 45454545455454545,
+                'candidate_id': 545454545454545, 'office_id': 54545545454454}
+        result_vote = self.send_auth_request(
+            "/api/v2/votes", "POST", data=vote)
+        self.assertEqual(result_vote.status_code, 400)


### PR DESCRIPTION
#### What does this PR do?

       - Add /auth/admin to create more admins
	- Add /candidates to get all candidates
	- Remove default admin from readme and config
	- Add default admin form env file
	- Increase test coverage
#### Description of Task to be completed?

 -Check your tests coverage
 - Remove the admin creds from the readme
 - Move the admin signup credentials to env
- Add an endpoint to for admin to make other users admin
#### How should this be manually tested?
1.  Follow install instructions on README.md file
2. `git checkout ch-feedback-add-env-164081078`
3. Re-run the app
4. Run pytest 
5. use Postman to test the endpoints

#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[#164081078](https://www.pivotaltracker.com/story/show/164081078)
#### Screenshots (if appropriate)
N/A


#### Questions:
N/A
